### PR TITLE
feat: add public provider registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,43 @@ npx 10x-chat@latest skill install
 
 This lets agents like Codex or Claude Code use 10x-chat to query other models for cross-validation, code review, or debugging help.
 
+## Custom Providers
+
+The package API supports out-of-tree providers for custom web chat sites. Register a provider before calling `runChat()`:
+
+```typescript
+import { registerProvider, runChat, type Provider } from '10x-chat';
+
+const customProvider = {
+  config: {
+    name: 'custom-chat',
+    displayName: 'Custom Chat',
+    url: 'https://chat.example.com',
+    loginUrl: 'https://chat.example.com/login',
+    defaultTimeoutMs: 300_000,
+  },
+  actions: {
+    isLoggedIn: (page) => page.locator('[data-user-menu]').isVisible(),
+    submitPrompt: async (page, prompt) => {
+      await page.locator('textarea').fill(prompt);
+      await page.getByRole('button', { name: 'Send' }).click();
+    },
+    captureResponse: async (page, { timeoutMs }) => {
+      const response = page.locator('[data-role="assistant"]').last();
+      await response.waitFor({ timeout: timeoutMs });
+      const text = (await response.innerText()).trim();
+      return { text, markdown: text, truncated: false };
+    },
+  },
+} satisfies Provider;
+
+registerProvider(customProvider);
+const result = await runChat({ provider: 'custom-chat', prompt: 'Hello' });
+console.log(result.response);
+```
+
+Provider names must be 1-64 lowercase letters, numbers, or hyphens and must start and end with a letter or number. Registration is process-local and rejects duplicate names, including attempts to replace built-in providers. A separate provider package can export the provider object or a registration function; the stock CLI does not dynamically discover npm packages.
+
 ## Supported Providers
 
 | Provider | Status | Models | URL |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 export { type BrowserSession, launchBrowser } from './browser/index.js';
 export { loadConfig, saveConfig } from './config.js';
 export { buildBundle, type ChatResult, runChat } from './core/index.js';
-export { getProvider, isValidProvider, listProviders } from './providers/index.js';
+export {
+  getProvider,
+  isValidProvider,
+  listProviders,
+  registerProvider,
+} from './providers/index.js';
 export {
   createSession,
   getSession,
@@ -9,6 +14,7 @@ export {
 } from './session/index.js';
 export type {
   AppConfig,
+  BuiltInProviderName,
   CapturedResponse,
   ChatOptions,
   ProfileMode,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,4 +5,4 @@ export { GEMINI_CONFIG, geminiActions } from './gemini.js';
 export { GROK_CONFIG, grokActions } from './grok.js';
 export { NOTEBOOKLM_CONFIG, notebooklmActions } from './notebooklm.js';
 export { PERPLEXITY_CONFIG, perplexityActions } from './perplexity.js';
-export { getProvider, isValidProvider, listProviders } from './registry.js';
+export { getProvider, isValidProvider, listProviders, registerProvider } from './registry.js';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,4 +1,4 @@
-import type { Provider, ProviderName } from '../types.js';
+import type { BuiltInProviderName, Provider, ProviderName } from '../types.js';
 import { CHATGPT_CONFIG, chatgptActions } from './chatgpt.js';
 import { CLAUDE_CONFIG, claudeActions } from './claude.js';
 import { DREAMINA_CONFIG, dreaminaActions } from './dreamina.js';
@@ -8,7 +8,7 @@ import { GROK_CONFIG, grokActions } from './grok.js';
 import { NOTEBOOKLM_CONFIG, notebooklmActions } from './notebooklm.js';
 import { PERPLEXITY_CONFIG, perplexityActions } from './perplexity.js';
 
-const PROVIDERS: Record<ProviderName, Provider> = {
+const BUILT_IN_PROVIDERS = {
   chatgpt: { config: CHATGPT_CONFIG, actions: chatgptActions },
   gemini: { config: GEMINI_CONFIG, actions: geminiActions },
   claude: { config: CLAUDE_CONFIG, actions: claudeActions },
@@ -17,23 +17,49 @@ const PROVIDERS: Record<ProviderName, Provider> = {
   notebooklm: { config: NOTEBOOKLM_CONFIG, actions: notebooklmActions },
   flow: { config: FLOW_CONFIG, actions: flowActions },
   dreamina: { config: DREAMINA_CONFIG, actions: dreaminaActions },
-};
+} satisfies Record<BuiltInProviderName, Provider>;
+
+const PROVIDERS = new Map<ProviderName, Provider>(
+  Object.values(BUILT_IN_PROVIDERS).map((provider) => [provider.config.name, provider] as const),
+);
+
+const PROVIDER_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+
+/**
+ * Register an out-of-tree provider for the lifetime of the current process.
+ *
+ * Provider names become CLI/profile slugs, so they are restricted to safe,
+ * lowercase path components. Existing providers cannot be overwritten.
+ */
+export function registerProvider(provider: Provider): void {
+  const name = provider?.config?.name;
+  if (typeof name !== 'string' || !PROVIDER_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid provider name "${String(name)}". Use 1-64 lowercase letters, numbers, or hyphens, starting and ending with a letter or number.`,
+    );
+  }
+  if (PROVIDERS.has(name)) {
+    throw new Error(`Provider "${name}" is already registered`);
+  }
+  PROVIDERS.set(name, provider);
+}
 
 /** Get a provider by name, throws if not found. */
-export function getProvider(name: ProviderName): Provider {
-  if (!Object.hasOwn(PROVIDERS, name)) {
-    const available = Object.keys(PROVIDERS).join(', ');
+export function getProvider(name: string): Provider {
+  const provider = PROVIDERS.get(name);
+  if (!provider) {
+    const available = listProviders().join(', ');
     throw new Error(`Unknown provider "${name}". Available: ${available}`);
   }
-  return PROVIDERS[name];
+  return provider;
 }
 
 /** List all registered provider names. */
 export function listProviders(): ProviderName[] {
-  return Object.keys(PROVIDERS) as ProviderName[];
+  return [...PROVIDERS.keys()];
 }
 
 /** Check if a string is a valid provider name. */
 export function isValidProvider(name: string): name is ProviderName {
-  return Object.hasOwn(PROVIDERS, name);
+  return PROVIDERS.has(name);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type ProfileMode = 'shared' | 'isolated';
 
 // ── Provider Types ──────────────────────────────────────────────
 
-export type ProviderName =
+export type BuiltInProviderName =
   | 'chatgpt'
   | 'gemini'
   | 'claude'
@@ -21,6 +21,14 @@ export type ProviderName =
   | 'notebooklm'
   | 'flow'
   | 'dreamina';
+
+/**
+ * A built-in provider name or a custom provider registered at runtime.
+ *
+ * The intersection preserves editor completions for built-in names while
+ * allowing external packages to use their own provider slug.
+ */
+export type ProviderName = BuiltInProviderName | (string & Record<never, never>);
 
 export interface ProviderConfig {
   name: ProviderName;

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,18 +1,47 @@
 import { describe, expect, it } from 'vitest';
-import { getProvider, isValidProvider, listProviders } from '../src/providers/registry.js';
+import {
+  getProvider,
+  isValidProvider,
+  listProviders,
+  type Provider,
+  registerProvider,
+} from '../src/index.js';
+
+function createCustomProvider(name: string): Provider {
+  return {
+    config: {
+      name,
+      displayName: 'Custom Chat',
+      url: 'https://chat.example.com',
+      loginUrl: 'https://chat.example.com/login',
+      defaultTimeoutMs: 30_000,
+    },
+    actions: {
+      isLoggedIn: () => Promise.resolve(true),
+      submitPrompt: () => Promise.resolve(),
+      captureResponse: () =>
+        Promise.resolve({
+          text: 'Custom response',
+          markdown: 'Custom response',
+          truncated: false,
+        }),
+    },
+  };
+}
 
 describe('Provider Registry', () => {
   it('should list all providers', () => {
     const providers = listProviders();
-    expect(providers).toContain('chatgpt');
-    expect(providers).toContain('gemini');
-    expect(providers).toContain('claude');
-    expect(providers).toContain('grok');
-    expect(providers).toContain('perplexity');
-    expect(providers).toContain('notebooklm');
-    expect(providers).toContain('flow');
-    expect(providers).toContain('dreamina');
-    expect(providers).toHaveLength(8);
+    expect(providers.slice(0, 8)).toEqual([
+      'chatgpt',
+      'gemini',
+      'claude',
+      'grok',
+      'perplexity',
+      'notebooklm',
+      'flow',
+      'dreamina',
+    ]);
   });
 
   it('should get a provider by name', () => {
@@ -24,10 +53,10 @@ describe('Provider Registry', () => {
   });
 
   it('should throw for unknown provider', () => {
-    expect(() => getProvider('unknown' as never)).toThrow('Unknown provider');
+    expect(() => getProvider('unknown')).toThrow('Unknown provider');
     // Prototype pollution guard
-    expect(() => getProvider('toString' as never)).toThrow('Unknown provider');
-    expect(() => getProvider('__proto__' as never)).toThrow('Unknown provider');
+    expect(() => getProvider('toString')).toThrow('Unknown provider');
+    expect(() => getProvider('__proto__')).toThrow('Unknown provider');
   });
 
   it('should get grok provider by name', () => {
@@ -61,4 +90,30 @@ describe('Provider Registry', () => {
     expect(isValidProvider('toString')).toBe(false);
     expect(isValidProvider('__proto__')).toBe(false);
   });
+
+  it('should register a custom provider through the public API', () => {
+    const provider = createCustomProvider('custom-chat');
+
+    registerProvider(provider);
+
+    expect(isValidProvider('custom-chat')).toBe(true);
+    expect(getProvider('custom-chat')).toBe(provider);
+    expect(listProviders()).toContain('custom-chat');
+  });
+
+  it('should reject duplicate provider names', () => {
+    const provider = createCustomProvider('duplicate-chat');
+    registerProvider(provider);
+
+    expect(() => registerProvider(provider)).toThrow('already registered');
+    expect(() => registerProvider(createCustomProvider('chatgpt'))).toThrow('already registered');
+  });
+
+  it.each(['', '../escape', 'UPPER', 'space name', '-leading', 'trailing-'])(
+    'should reject unsafe provider name %j',
+    (name) => {
+      expect(() => registerProvider(createCustomProvider(name))).toThrow('Invalid provider name');
+      expect(isValidProvider(name)).toBe(false);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- add a public `registerProvider()` API for out-of-tree web chat providers
- preserve built-in provider completions while allowing custom provider slugs
- reject unsafe names, duplicate registrations, and built-in overrides
- document the process-local custom-provider workflow

## Why

The architecture treats providers as plugins, but the published registry was closed. This lets custom-site integrations live in separate packages and use `runChat()` without modifying 10x-chat core.

Closes #7.

## Validation

- `npm run build`
- `npx biome check --no-errors-on-unmatched src/ tests/registry.test.ts`
- `npm test` (18 files, 157 tests)
- built-package runtime import/registration smoke test
- `npm pack --dry-run --json`

Biome reports the same two pre-existing duplicate-enum-value warnings in `src/notebooklm/rpc/types.ts`; there are no new lint errors.