### PR TITLE
fix(chatgpt): select Chat mode before delegation

### DIFF
--- a/src/providers/chatgpt.ts
+++ b/src/providers/chatgpt.ts
@@ -52,7 +52,8 @@ const SELECTORS = {
     '#prompt-textarea.ProseMirror[contenteditable="true"][role="textbox"], #prompt-textarea[contenteditable="true"], [data-testid="composer-input"], div.ProseMirror[contenteditable="true"], textarea, .wcDTda_fallbackTextarea',
   sendButton:
     '#composer-submit-button, button[aria-label="Send prompt"], [data-testid="send-button"]',
-  stopButton: 'button[aria-label="Stop streaming"]',
+  stopButton:
+    'button[aria-label="Stop streaming"], button[data-testid="stop-button"], button[aria-label="Stop answering"]',
   assistantTurn: ASSISTANT_TURN_FALLBACK_SELECTORS.join(', '),
   loginPage: 'button:has-text("Log in"), button:has-text("Sign up")',
   /** Hidden file input — exclude the dedicated photo/camera inputs */
@@ -61,6 +62,85 @@ const SELECTORS = {
     'button[data-testid="model-switcher-dropdown-button"], button[aria-label="Model selector"], button[aria-label*="model" i], button[aria-haspopup="menu"], button[aria-haspopup="listbox"], button[aria-haspopup="dialog"]',
   modelOption: '[role="menuitem"]',
 } as const;
+
+class ChatGptModeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChatGptModeError';
+  }
+}
+
+interface ChatModeState {
+  chatVisible: boolean;
+  workVisible: boolean;
+  chatActive: boolean;
+  workActive: boolean;
+}
+
+async function readChatModeState(page: Page): Promise<ChatModeState> {
+  return page.evaluate(() => {
+    const normalize = (value: string | null | undefined) =>
+      (value ?? '').replace(/\s+/g, ' ').trim();
+    const visible = (element: Element | undefined): element is HTMLElement => {
+      if (!(element instanceof HTMLElement) || element.hidden) return false;
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    const controls = Array.from(document.querySelectorAll('button[role="radio"]'));
+    const chat = controls.find((element) => normalize(element.textContent) === 'Chat');
+    const work = controls.find((element) => normalize(element.textContent) === 'Work');
+    const active = (element: Element | undefined) =>
+      element?.getAttribute('aria-checked') === 'true' ||
+      element?.getAttribute('data-state') === 'on';
+
+    return {
+      chatVisible: visible(chat),
+      workVisible: visible(work),
+      chatActive: visible(chat) && active(chat),
+      workActive: visible(work) && active(work),
+    };
+  });
+}
+
+async function clickChatMode(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const normalize = (value: string | null | undefined) =>
+      (value ?? '').replace(/\s+/g, ' ').trim();
+    const chat = Array.from(document.querySelectorAll('button[role="radio"]')).find(
+      (element) => normalize(element.textContent) === 'Chat',
+    );
+    if (!(chat instanceof HTMLElement)) return false;
+    chat.click();
+    return true;
+  });
+}
+
+/** Keep ordinary chat delegation off the independently metered Work surface. */
+export async function ensureChatMode(page: Page): Promise<void> {
+  const initial = await readChatModeState(page);
+
+  // Some accounts and the signed-out interface do not expose a mode switcher.
+  if (!initial.chatVisible && !initial.workVisible) return;
+  if (!initial.chatVisible) {
+    throw new ChatGptModeError('ChatGPT Work mode is visible, but Chat mode is unavailable');
+  }
+  if (initial.chatActive && !initial.workActive) return;
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (!(await clickChatMode(page))) break;
+    await page.waitForTimeout(100);
+    const current = await readChatModeState(page);
+    if (current.chatActive && !current.workActive) return;
+  }
+
+  throw new ChatGptModeError('Could not switch ChatGPT from Work to Chat mode');
+}
 
 const MODEL_OPTION_SCOPE_SELECTORS = [
   '[role="menu"]',
@@ -344,6 +424,7 @@ export class CloudflareBlockedError extends Error {
 export const chatgptActions: ProviderActions = {
   async selectModel(page: Page, model: string): Promise<void> {
     await dismissOverlays(page);
+    await ensureChatMode(page);
 
     const picker = await getVisibleModelPickerState(page);
     if (!picker.found) {
@@ -406,7 +487,10 @@ export const chatgptActions: ProviderActions = {
         }
         return false;
       }, SELECTORS.composer);
-      if (composerVisible) return true;
+      if (composerVisible) {
+        await ensureChatMode(page);
+        return true;
+      }
 
       const loginVisible = await page
         .locator(SELECTORS.loginPage)
@@ -418,12 +502,13 @@ export const chatgptActions: ProviderActions = {
       return false;
     } catch (err) {
       // Re-throw Cloudflare errors so the orchestrator can surface them
-      if (err instanceof CloudflareBlockedError) throw err;
+      if (err instanceof CloudflareBlockedError || err instanceof ChatGptModeError) throw err;
       return false;
     }
   },
 
   async attachFiles(page: Page, filePaths: string[]): Promise<void> {
+    await ensureChatMode(page);
     const fileInput = page.locator(SELECTORS.fileInput).first();
     await fileInput.setInputFiles(filePaths);
     // Wait for upload indicators to appear and settle
@@ -433,6 +518,7 @@ export const chatgptActions: ProviderActions = {
   async submitPrompt(page: Page, prompt: string): Promise<void> {
     // Dismiss onboarding/welcome modals that block the composer
     await dismissOverlays(page);
+    await ensureChatMode(page);
 
     await submitPromptToComposer(page, prompt, {
       composerSelector: SELECTORS.composer,

--- a/tests/chatgpt-capture.test.ts
+++ b/tests/chatgpt-capture.test.ts
@@ -68,6 +68,9 @@ describe('ChatGPT Provider', () => {
       expect(response.text).toBe('Hello');
       expect(response.markdown).toBe('<p>Hello</p>');
       expect(page.evaluate).toHaveBeenCalled();
+      expect(page.locator).toHaveBeenCalledWith(
+        expect.stringContaining('data-testid="stop-button"'),
+      );
     });
 
     it('streams chunk deltas from evaluate-based snapshots', async () => {

--- a/tests/chatgpt-mode.test.ts
+++ b/tests/chatgpt-mode.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureChatMode } from '../src/providers/chatgpt.js';
+
+type Mode = 'Chat' | 'Work';
+
+function createModePage(
+  options: { active?: Mode; visible?: Mode[]; switchOnClick?: boolean } = {},
+) {
+  let active = options.active;
+  const visible = new Set(options.visible ?? ['Chat', 'Work']);
+  const switchOnClick = options.switchOnClick ?? true;
+  const clicks: Mode[] = [];
+
+  return {
+    page: {
+      evaluate: vi.fn(async (callback: unknown) => {
+        if (String(callback).includes('chat.click()')) {
+          clicks.push('Chat');
+          if (switchOnClick) active = 'Chat';
+          return true;
+        }
+        return {
+          chatVisible: visible.has('Chat'),
+          workVisible: visible.has('Work'),
+          chatActive: visible.has('Chat') && active === 'Chat',
+          workActive: visible.has('Work') && active === 'Work',
+        };
+      }),
+      waitForTimeout: vi.fn(async () => {}),
+    },
+    clicks,
+    active: () => active,
+  };
+}
+
+describe('ChatGPT mode selection', () => {
+  it('switches a persisted Work session to Chat and verifies the state', async () => {
+    const { page, clicks, active } = createModePage({ active: 'Work' });
+
+    await ensureChatMode(page as never);
+
+    expect(clicks).toEqual(['Chat']);
+    expect(active()).toBe('Chat');
+  });
+
+  it('does not click when Chat is already active', async () => {
+    const { page, clicks } = createModePage({ active: 'Chat' });
+
+    await ensureChatMode(page as never);
+
+    expect(clicks).toEqual([]);
+  });
+
+  it('preserves compatibility for accounts without the mode switcher', async () => {
+    const { page, clicks } = createModePage({ visible: [] });
+
+    await ensureChatMode(page as never);
+
+    expect(clicks).toEqual([]);
+  });
+
+  it('fails closed when Work is available but Chat cannot be selected', async () => {
+    const { page } = createModePage({ active: 'Work', switchOnClick: false });
+
+    await expect(ensureChatMode(page as never)).rejects.toThrow(
+      'Could not switch ChatGPT from Work to Chat mode',
+    );
+  });
+});

--- a/tests/chatgpt-overlay.test.ts
+++ b/tests/chatgpt-overlay.test.ts
@@ -121,7 +121,14 @@ describe('ChatGPT Overlay Dismissal', () => {
         // forced modal removal path in dismissOverlays
         .mockResolvedValueOnce(true)
         // composer visible check in isLoggedIn
-        .mockResolvedValueOnce(true),
+        .mockResolvedValueOnce(true)
+        // account has no Chat/Work mode switcher
+        .mockResolvedValueOnce({
+          chatVisible: false,
+          workVisible: false,
+          chatActive: false,
+          workActive: false,
+        }),
       url: vi.fn(() => 'https://chatgpt.com'),
       title: vi.fn(async () => 'ChatGPT'),
     };
@@ -130,7 +137,7 @@ describe('ChatGPT Overlay Dismissal', () => {
 
     const result = await chatgptActions.isLoggedIn(page as never);
     expect(result).toBe(true);
-    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
   });
 
   it('should handle overlay dismissal errors gracefully', async () => {

--- a/tests/model-selection.test.ts
+++ b/tests/model-selection.test.ts
@@ -37,7 +37,11 @@ function createModelPage(evaluateResults: unknown[]) {
 
 describe('Model selection uses Playwright locator clicks to open the menu', () => {
   it('selects a ChatGPT model after opening the picker through a locator click', async () => {
-    const page = createModelPage([{ found: true, text: 'Thinking' }, true]);
+    const page = createModelPage([
+      { chatVisible: false, workVisible: false, chatActive: false, workActive: false },
+      { found: true, text: 'Thinking' },
+      true,
+    ]);
 
     await chatgptActions.selectModel(page as never, 'Instant');
 
@@ -49,7 +53,7 @@ describe('Model selection uses Playwright locator clicks to open the menu', () =
     );
     expect(modelPicker?.first).toHaveBeenCalledTimes(1);
     expect(modelPicker?.click).toHaveBeenCalledTimes(1);
-    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
     expect(page.waitForTimeout).toHaveBeenCalledWith(750);
     expect(page.waitForTimeout).toHaveBeenCalledWith(500);
     expect(page.keyboard.press).not.toHaveBeenCalled();

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -109,11 +109,15 @@ describe('Provider Registry', () => {
     expect(() => registerProvider(createCustomProvider('chatgpt'))).toThrow('already registered');
   });
 
-  it.each(['', '../escape', 'UPPER', 'space name', '-leading', 'trailing-'])(
-    'should reject unsafe provider name %j',
-    (name) => {
-      expect(() => registerProvider(createCustomProvider(name))).toThrow('Invalid provider name');
-      expect(isValidProvider(name)).toBe(false);
-    },
-  );
+  it.each([
+    '',
+    '../escape',
+    'UPPER',
+    'space name',
+    '-leading',
+    'trailing-',
+  ])('should reject unsafe provider name %j', (name) => {
+    expect(() => registerProvider(createCustomProvider(name))).toThrow('Invalid provider name');
+    expect(isValidProvider(name)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- detect ChatGPT's visible Chat/Work radio control and switch persisted Work sessions to Chat
- verify Chat remains active before readiness, model selection, file attachment, and prompt submission
- preserve compatibility for accounts and signed-out sessions that do not expose the mode control
- recognize the current `data-testid="stop-button"` / `aria-label="Stop answering"` streaming control

## Why

ChatGPT now persists Chat and Work as UI modes at the same root URL. A provider launch can therefore land in Work even though the URL is `https://chatgpt.com/`, causing ordinary chat automation to use the wrong, separately metered surface.

## Validation

- `npm run build`
- `npx @biomejs/biome@2.4.4 check .`
- `npm test` (161 tests)
- headed smoke test from a persisted Work session; readiness completed with Chat selected and Work deselected

## CI compatibility

This also applies the locked Biome 2.4.4 formatter to the existing provider-registry test block that CI checks.