### PR TITLE
fix: unblock release by formatting provider registry tests

### DIFF
--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -109,11 +109,15 @@ describe('Provider Registry', () => {
     expect(() => registerProvider(createCustomProvider('chatgpt'))).toThrow('already registered');
   });
 
-  it.each(['', '../escape', 'UPPER', 'space name', '-leading', 'trailing-'])(
-    'should reject unsafe provider name %j',
-    (name) => {
-      expect(() => registerProvider(createCustomProvider(name))).toThrow('Invalid provider name');
-      expect(isValidProvider(name)).toBe(false);
-    },
-  );
+  it.each([
+    '',
+    '../escape',
+    'UPPER',
+    'space name',
+    '-leading',
+    'trailing-',
+  ])('should reject unsafe provider name %j', (name) => {
+    expect(() => registerProvider(createCustomProvider(name))).toThrow('Invalid provider name');
+    expect(isValidProvider(name)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- Apply the locked Biome 2.4.4 formatter to the provider-registry unsafe-name test.
- Preserve all test cases, assertions, and runtime behavior.

## Why

The [v0.11.7 release workflow](https://github.com/MikeChongCan/10x-chat/actions/runs/31625527620/job/94210819361) failed at Lint, before tests, build, and npm publication. Running the locked formatter at the tagged commit reproduces one formatting error in `tests/registry.test.ts`.

This isolates the formatting correction already present in #9 so release recovery does not depend on reviewing the Chat/Work changes. This PR does not modify #9.

## Validation

Using Bun 1.3.14 and the frozen lockfile:
- `bun install --frozen-lockfile --ignore-scripts` (no dependency changes)
- `bun run typecheck`
- `bun run lint` (98 files checked; the failure reproduces before this change and passes afterward)
- `bun run test` (157 tests across 18 files passed)
- `bun run build`
- `npm pack --dry-run --ignore-scripts --json`
- Parsed TypeScript syntax comparison confirms no changes apart from source layout.

## Release Follow-Up

After merging, could you publish a fresh patch release, such as v0.11.8? That would make the merged public provider-registration API available to downstream extensions through npm. No version, workflow, or dependency changes are included here; the existing v0.11.7 tag is left untouched.
